### PR TITLE
Updated Form component API call to include fields

### DIFF
--- a/src/pages/Form.js
+++ b/src/pages/Form.js
@@ -21,7 +21,11 @@ function Form() {
   const formRef = useRef(null)
 
   const { data, loading, error } = useFetch({
-    url: new URL(id, url).href
+    url: new URL(id, url).href,
+    parameters: {
+      key: 'include',
+      value: 'fields'
+    }
   })
 
   const { control, handleSubmit, reset } = useForm()


### PR DESCRIPTION
The API endpoint no longer automatically includes the fields so we need to manually include the relationship.